### PR TITLE
Fix API logging environment variable check

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,8 +124,7 @@ function _bindMiddlewares() {
 }
 
 function _loggingEnabled() {
-  const { API_LOGGING } = ENV_VARS;
-  return process.env[API_LOGGING] || parsony.configs[LOGGING];
+  return process.env.API_LOGGING === 'true' || parsony.configs[LOGGING];
 }
 
 function _add404(pathTo404) {


### PR DESCRIPTION
## Problem
The API logging environment variable (API_LOGGING=true) was not being properly detected due to how environment variables were being checked in the code.

## Solution
Modified the _loggingEnabled() function to directly check process.env.API_LOGGING for the string value 'true', while maintaining the existing config-based logging setting as a fallback.

## Testing
- Verified logging enables when starting with `API_LOGGING=true npm start`
- Confirmed logging still works through config file settings
- Ensured backward compatibility with existing logging behavior

## Changes
- Updated environment variable check in _loggingEnabled() function